### PR TITLE
fix: fixes stats parsing for single creatures with a display name

### DIFF
--- a/src/encounter/index.ts
+++ b/src/encounter/index.ts
@@ -177,6 +177,8 @@ export class EncounterParser {
                 ? number
                 : Number(match[1]);
             monster = match[2];
+        } else if (Array.isArray(raw)) {
+            monster = raw;
         } else if (typeof raw == "object") {
             let entries = Object.entries(raw).flat();
             number = entries[0];


### PR DESCRIPTION
Fixes the following documented encounter syntax that is currently not working correctly:

````
```encounter
  -
    - [Hobgoblin, Jim]
    - 12
    - 13
    - 2
    - 25
```
````

The same syntax works with the creature count specified but fails in this case since it previously interpreted the array as an object and only used the creature & display name but discarded the stat overrides.
