### PR TITLE
Bring back statblock-link functionality

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -654,6 +654,6 @@ export default class InitiativeTracker extends Plugin {
             });
         }
 
-        this.combatant.render(creature);
+        await this.combatant.render(creature);
     }
 }

--- a/src/tracker/view.ts
+++ b/src/tracker/view.ts
@@ -2,7 +2,10 @@ import {
     debounce,
     ExtraButtonComponent,
     ItemView,
+    MarkdownRenderer,
     Notice,
+    parseLinktext,
+    resolveSubpath,
     WorkspaceLeaf
 } from "obsidian";
 import {
@@ -126,15 +129,15 @@ export class CreatureView extends ItemView {
         new ExtraButtonComponent(this.buttonEl)
             .setIcon("cross")
             .setTooltip("Close Statblock")
-            .onClick(() => {
-                this.render();
+            .onClick(async () => {
+                await this.render();
                 this.app.workspace.trigger("initiative-tracker:stop-viewing");
             });
     }
     onunload(): void {
         this.app.workspace.trigger("initiative-tracker:stop-viewing");
     }
-    render(creature?: HomebrewCreature) {
+    async render(creature?: HomebrewCreature) {
         this.statblockEl.empty();
         if (!creature) {
             this.statblockEl.createEl("em", {
@@ -143,10 +146,16 @@ export class CreatureView extends ItemView {
             return;
         }
 
-        if (
+        const tryStatblockPlugin =
             this.plugin.canUseStatBlocks &&
-            this.plugin.statblockVersion?.major >= 2
+            this.plugin.statblockVersion?.major >= 2;
+
+        if (
+            creature["statblock-link"] &&
+            (this.plugin.data.preferStatblockLink || !tryStatblockPlugin)
         ) {
+            await this.renderEmbed(creature["statblock-link"]);
+        } else if (tryStatblockPlugin) {
             const statblock = this.plugin.statblocks.render(
                 creature,
                 this.statblockEl,
@@ -155,10 +164,43 @@ export class CreatureView extends ItemView {
             this.addChild(statblock);
         } else {
             this.statblockEl.createEl("em", {
-                text: "Install the TTRPG Statblocks plugin to use this feature!"
+                text: "Install the TTRPG Statblocks plugin or add a statblock-link to your monster to use this feature!",
             });
         }
     }
+
+    async renderEmbed(embedLink: string) {
+        if (/\[.+\]\(.+\)/.test(embedLink)) {
+            //md
+            [, embedLink] = embedLink.match(/\[.+?\]\((.+?)\)/);
+        } else if (/\[\[.+\]\]/.test(embedLink)) {
+            //wiki
+            [, embedLink] = embedLink.match(/\[\[(.+?)(?:\|.+?)?\]\]/);
+        }
+
+        const {path, subpath} = parseLinktext(embedLink);
+        const file = this.app.metadataCache.getFirstLinkpathDest(path, '/');
+        const fileContent = await app.vault.cachedRead(file);
+
+        let content = `Oops! Something is wrong with your statblock-link:<br />${embedLink}`;
+        if (subpath && fileContent) {
+            const cache = app.metadataCache.getFileCache(file);
+            const subpathResult = resolveSubpath(cache, subpath);
+            if (subpathResult) {
+                content = fileContent.slice(subpathResult.start.offset, subpathResult.end.offset);
+            }
+        } else if (fileContent) {
+            content = fileContent;
+        }
+
+        await MarkdownRenderer.renderMarkdown(
+            content,
+            this.statblockEl.createDiv("markdown-rendered"),
+            path,
+            null
+        );
+    }
+
     getDisplayText(): string {
         return "Combatant";
     }


### PR DESCRIPTION
Somehow it seems like some of the code in `view.ts` from [this pr](https://github.com/valentine195/initiative-tracker/pull/92) by @ebullient got lost at some point. The setting to use the statblock links is still there, but does nothing. This PR just brings back that functionality.

<img width="742" alt="Screenshot 2023-03-09 at 11 44 32 PM" src="https://user-images.githubusercontent.com/12775745/224225515-ec27a965-9db3-40b6-a6bb-52bae3ee3bc9.png">
