### PR TITLE
🐛 defer construction of statblock link

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -292,10 +292,7 @@ export default class InitiativeTracker extends Plugin {
                         player.modifier = modifier;
                         player.level = level;
                         player.name = name ? name : player.name;
-                        this.setStatblockLink(
-                            player,
-                            frontmatter["statblock-link"]
-                        );
+                        player["statblock-link"] = frontmatter["statblock-link"];
 
                         this.playerCreatures.set(
                             player.name,
@@ -347,14 +344,6 @@ export default class InitiativeTracker extends Plugin {
         });
 
         console.log("Initiative Tracker v" + this.manifest.version + " loaded");
-    }
-
-    setStatblockLink(player: HomebrewCreature, newValue: string) {
-        if (newValue) {
-            player["statblock-link"] = newValue.startsWith("#")
-                ? `[${player.name}](${player.path}${newValue})`
-                : newValue;
-        }
     }
 
     addCommands() {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1080,11 +1080,7 @@ class NewPlayerModal extends Modal {
                     this.player.hp = hp;
                     this.player.level = level;
                     this.player.modifier = modifier;
-                    this.plugin.setStatblockLink(
-                        this.player,
-                        metaData.frontmatter["statblock-link"]
-                    );
-
+                    this.player["statblock-link"] = metaData.frontmatter["statblock-link"];
                     this.display();
                 };
             });

--- a/src/tracker/ui/creatures/Creature.svelte
+++ b/src/tracker/ui/creatures/Creature.svelte
@@ -14,6 +14,7 @@
     $: statuses = creature.status;
 
     const name = () => creature.getName();
+    const statblockLink = () => creature.getStatblockLink();
     const hiddenIcon = (div: HTMLElement) => {
         setIcon(div, HIDDEN);
     };
@@ -25,7 +26,7 @@
     const tryHover = (evt: MouseEvent) => {
         hoverTimeout = setTimeout(() => {
             if (creature["statblock-link"]) {
-                let link = creature["statblock-link"];
+                let link = statblockLink();
                 if (/\[.+\]\(.+\)/.test(link)) {
                     //md
                     [, link] = link.match(/\[.+?\]\((.+?)\)/);

--- a/src/tracker/view.ts
+++ b/src/tracker/view.ts
@@ -129,7 +129,7 @@ export class CreatureView extends ItemView {
     onunload(): void {
         this.app.workspace.trigger("initiative-tracker:stop-viewing");
     }
-    async render(creature?: HomebrewCreature) {
+    async render(creature?: Creature) {
         this.statblockEl.empty();
         if (!creature) {
             this.statblockEl.createEl("em", {
@@ -146,7 +146,7 @@ export class CreatureView extends ItemView {
             creature["statblock-link"] &&
             (this.plugin.data.preferStatblockLink || !tryStatblockPlugin)
         ) {
-            await this.renderEmbed(creature["statblock-link"]);
+            await this.renderEmbed(creature.getStatblockLink());
         } else if (tryStatblockPlugin) {
             const statblock = this.plugin.statblocks.render(
                 creature,

--- a/src/utils/creature.ts
+++ b/src/utils/creature.ts
@@ -115,6 +115,14 @@ export class Creature {
         }
         return name.join(" ");
     }
+    getStatblockLink(): string {
+        if ("statblock-link" in this) {
+            const value = this["statblock-link"];
+            return value.startsWith("#")
+                ? `[${this.name}](${this.note}${value})`
+                : value;
+        }
+    }
 
     *[Symbol.iterator]() {
         yield this.name;


### PR DESCRIPTION
Defer construction of statblock link (resolving anchor links) until render time, so it catches all paths.